### PR TITLE
fix:修复手柄断线重连问题

### DIFF
--- a/src/joystick_task.cpp
+++ b/src/joystick_task.cpp
@@ -20,6 +20,7 @@ void JoystickTask_t::run(void *pvParameters)
 
     while (true)
     {
+        //修复断线重连 /test/onloop
         xboxController.onLoop();
         if (xboxController.isConnected())
         {

--- a/test/onloop.md
+++ b/test/onloop.md
@@ -1,0 +1,38 @@
+# 蓝牙Xbox断线重连修复
+```
+void onLoop() {
+    //数据超时判断
+    if (isConnected()) {
+      // 检测数据超时（如 2 秒无数据视为断线）
+      if (millis() - receivedNotificationAt > 1000) {
+        Serial.println("Force disconnect due to timeout");
+        // 强制转化为扫描模式
+        connectionState = ConnectionState::Scanning;
+        if (pConnectedClient) {
+          pConnectedClient->disconnect();
+        }
+      }
+    }
+
+    if (!isConnected()) {
+      receivedNotificationAt = 0;
+      receivedBatteryAt = 0;
+      if (advDevice != nullptr) {
+        auto connectionResult = connectToServer(advDevice);
+        if (!connectionResult || !isConnected()) {
+          NimBLEDevice::deleteBond(advDevice->getAddress());
+          ++countFailedConnection;
+          // reset();
+          connectionState = ConnectionState::Scanning;
+        } else {
+          countFailedConnection = 0;
+        }
+        advDevice = nullptr;
+
+      } else if (!isScanning()) {
+        // reset();
+        startScan();
+      }
+    }
+  }
+  ```


### PR DESCRIPTION
在原本xbox手柄开源库中修改onloop函数，增加接收时间戳检测逻辑，使其在1s未接受到数据后强制进入扫描模式，即非连接状态